### PR TITLE
remove CSS class that is not used anywhere

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,8 +6,3 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
-}


### PR DESCRIPTION
I couldn't find any place where `code` class is used.

Could we remove it?